### PR TITLE
Fix github venue

### DIFF
--- a/draft-ietf-ccwg-rfc8298bis-screamv2.md
+++ b/draft-ietf-ccwg-rfc8298bis-screamv2.md
@@ -12,7 +12,7 @@ submissiontype: IETF
 venue:
   group: Congestion Control Working Group (ccwg)
   mail: ccwg@ietf.org
-  github: gloinul/draft-johansson-ccwg-scream-bis
+  github: IngJohEricsson/draft-johansson-ccwg-scream-bis
 
 author:
   -


### PR DESCRIPTION
The link to the GitHub repository and issue tracker of the draft points to the wrong location.